### PR TITLE
add a support that it can be used in Java source code.

### DIFF
--- a/src/org/computer/aman/metrics/complexity/cyclomatic/CyclomaticNumberCounter.jj
+++ b/src/org/computer/aman/metrics/complexity/cyclomatic/CyclomaticNumberCounter.jj
@@ -47,7 +47,7 @@ import java.io.*;
  */
 public class CyclomaticNumberCounter
 {
-   static int count = 0;
+   private int count = 0;
 
    /**
     * Class to hold modifiers.
@@ -149,7 +149,7 @@ public class CyclomaticNumberCounter
 
     CyclomaticNumberCounter parser;
     String fileName = null;
-    
+
     if (args.length == 0) {
       System.err.println("Reading from standard input . . .");
       fileName = "(standard input)";
@@ -170,18 +170,23 @@ public class CyclomaticNumberCounter
 			return;
       }
     }
-    
+
     try {
-      System.err.println("====================================================================");      
+      System.err.println("====================================================================");
       parser.CompilationUnit();
       System.err.println("The cyclomatic number is counted successfully.");
-      System.out.println(fileName + "," + (count + 1));
-      System.err.println("====================================================================");      
+      System.out.println(fileName + "," + parser.getCyclomaticNumber());
+      System.err.println("====================================================================");
     }
     catch (ParseException e) {
       System.err.println(e.getMessage());
       System.err.println("***  Encountered errors during parse.");
     }
+  }
+
+  public int getCyclomaticNumber()
+  {
+    return this.count+1;
   }
 }
 


### PR DESCRIPTION
Please edit the version number, copyright year and so on if you receive this pull request.
If you do not like this, please do not hesitate to delete
because I have something more to learn about javacc.

We can specify the analysis target in the Java program
and get the cyclomatic number by invoking "getCyclomaticNumber" method.
Previously, this tool was supposed to be used on the command line.
This commit has expanded the possibilities.

Specifically, we make two major changes.
First, we made the "count" variable a non-static field.
In the second, we added a getter method that returns a cyclomatic
number.